### PR TITLE
Fix GitHub Pages workflow configuration

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,6 +45,9 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v4
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- add the missing configure-pages step so deployments can request the Pages deployment token

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5d810a8dc8327a006f0b0edae060e