### PR TITLE
Update GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,13 +18,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Put pnpm on PATH first
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
-
-      - run: corepack enable
-      - run: corepack prepare pnpm@9 --activate
+          cache: 'pnpm'               # now safe, pnpm exists
+          cache-dependency-path: pnpm-lock.yaml
 
       - run: pnpm -v
 


### PR DESCRIPTION
## Summary
- replace the GitHub Pages workflow with a version that sets up pnpm before caching with setup-node and builds with pnpm

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5da8d2ac88327a68b42a13336a82b