### PR TITLE
Replace favicon with SVG asset

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>India Food × Cancer</title>
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
     <link rel="stylesheet" href="/src/ui/app.css" />
   </head>
   <body>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#ef4444" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="url(#g)" />
+  <text x="50%" y="52%" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="34" font-weight="700" fill="#fff">I</text>
+</svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  base: './',
   build: {
     outDir: 'dist',
     sourcemap: false


### PR DESCRIPTION
## Summary
- swap the favicon link to reference a relative SVG asset compatible with non-root hosting
- add a text-based SVG favicon and drop the previous binary `.ico` file

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d5dd24a6b8832796134f628404933c