### PR TITLE
Refine cancer view layout

### DIFF
--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -73,6 +73,14 @@ nav {
   align-items: flex-start;
 }
 
+.card {
+  background: rgba(9, 28, 44, 0.82);
+  border-radius: 0.9rem;
+  box-shadow: var(--shadow-elevated);
+  padding: 1.5rem;
+  border: 1px solid rgba(245, 247, 250, 0.06);
+}
+
 .map-column,
 .panel-column {
   background: rgba(9, 28, 44, 0.82);
@@ -90,6 +98,75 @@ nav {
   flex: 1 1 40%;
   max-height: 90vh;
   overflow-y: auto;
+}
+
+.cancer-layout {
+  display: grid;
+  gap: 1.75rem;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.cancer-map-card {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.cancer-map-container {
+  width: 100%;
+}
+
+.cancer-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: flex-end;
+}
+
+.cancer-controls .control-group {
+  min-width: 220px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.cancer-controls label {
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.legend-panel {
+  flex: 1 1 320px;
+  min-width: 260px;
+}
+
+.legend-panel h3 {
+  margin: 0 0 0.65rem;
+  font-size: 1.05rem;
+  color: var(--color-cream);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.cancer-stats-card {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.stats-section {
+  display: flex;
+  flex-direction: column;
+}
+
+.stats-section h3 {
+  margin: 0 0 0.65rem;
+  font-size: 1.05rem;
+  color: var(--color-cream);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
 
 .panel-section + .panel-section {
@@ -312,5 +389,13 @@ nav {
 
   .panel-column {
     max-height: unset;
+  }
+
+  .cancer-controls {
+    align-items: stretch;
+  }
+
+  .legend-panel {
+    flex-basis: 100%;
   }
 }

--- a/src/ui/viewCancer.ts
+++ b/src/ui/viewCancer.ts
@@ -11,40 +11,51 @@ export function renderCancerView(root: HTMLElement, data: AppData) {
   root.className = 'view view-cancer';
 
   const layout = document.createElement('div');
-  layout.className = 'view-grid';
-  const mapContainer = document.createElement('div');
-  mapContainer.className = 'map-column';
-  const panel = document.createElement('div');
-  panel.className = 'panel-column';
-
-  layout.append(mapContainer, panel);
+  layout.className = 'cancer-layout';
   root.append(layout);
+
+  const mapCard = document.createElement('section');
+  mapCard.className = 'card cancer-map-card';
+  layout.append(mapCard);
+
+  const mapContainer = document.createElement('div');
+  mapContainer.className = 'cancer-map-container';
+  mapCard.append(mapContainer);
+
+  const controls = document.createElement('div');
+  controls.className = 'cancer-controls';
+  controls.innerHTML = `
+    <div class="control-group">
+      <label for="cancer-year">Year</label>
+      <select id="cancer-year" class="control"></select>
+    </div>
+    <div class="legend-panel">
+      <h3>Legend</h3>
+      <div class="legend-container"></div>
+    </div>
+  `;
+  mapCard.append(controls);
+
+  const statsCard = document.createElement('section');
+  statsCard.className = 'card cancer-stats-card';
+  statsCard.innerHTML = `
+    <div class="stats-section">
+      <h3>Top 5 incidence</h3>
+      <ol class="list top-list"></ol>
+    </div>
+    <div class="stats-section">
+      <h3>Bottom 5 incidence</h3>
+      <ol class="list bottom-list"></ol>
+    </div>
+  `;
+  layout.append(statsCard);
 
   const choropleth = createChoropleth({
     container: mapContainer,
     topology: data.topology
   });
 
-  panel.innerHTML = `
-    <div class="panel-section">
-      <label for="cancer-year">Year</label>
-      <select id="cancer-year" class="control"></select>
-    </div>
-    <div class="panel-section">
-      <h3>Legend</h3>
-      <div class="legend-container"></div>
-    </div>
-    <div class="panel-section">
-      <h3>Top 5 incidence</h3>
-      <ol class="list top-list"></ol>
-    </div>
-    <div class="panel-section">
-      <h3>Bottom 5 incidence</h3>
-      <ol class="list bottom-list"></ol>
-    </div>
-  `;
-
-  const yearSelect = panel.querySelector<HTMLSelectElement>('#cancer-year')!;
+  const yearSelect = controls.querySelector<HTMLSelectElement>('#cancer-year')!;
   YEARS.forEach((year) => {
     const option = document.createElement('option');
     option.value = year;
@@ -53,10 +64,10 @@ export function renderCancerView(root: HTMLElement, data: AppData) {
   });
   yearSelect.value = '2022';
 
-  const legend = createLegend({ container: panel.querySelector('.legend-container') as HTMLElement });
+  const legend = createLegend({ container: controls.querySelector('.legend-container') as HTMLElement });
 
-  const topList = panel.querySelector<HTMLOListElement>('.top-list')!;
-  const bottomList = panel.querySelector<HTMLOListElement>('.bottom-list')!;
+  const topList = statsCard.querySelector<HTMLOListElement>('.top-list')!;
+  const bottomList = statsCard.querySelector<HTMLOListElement>('.bottom-list')!;
 
   const byState = new Map(data.cancer.map((row) => [row.state, row]));
 


### PR DESCRIPTION
## Summary
- move the cancer choropleth year selector and legend below the map to emphasize the visualization
- restyle the cancer view layout with shared card styling and responsive tweaks to remove the secondary scrollbar

## Testing
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5e40f21148327953849842923f2c5