### PR TITLE
Add footer about panel with usage guidance

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,36 @@
   <body>
     <nav id="nav"></nav>
     <div id="app"></div>
+    <footer class="about-panel">
+      <div class="about-panel__content">
+        <h2>About this dashboard</h2>
+        <div class="about-panel__grid">
+          <section>
+            <h3>How to use it</h3>
+            <p>
+              Switch between the Cancer, Cuisine, and Compare tabs above to explore different perspectives. Hover or tap states
+              on the map for quick metrics and use the controls in each panel to filter, sort, and drill into the underlying
+              data.
+            </p>
+          </section>
+          <section>
+            <h3>Data sources</h3>
+            <p>
+              Cancer incidence totals come from the Rajya Sabha 2019–2022 reports. Cuisine features are aggregated from the
+              Archana&rsquo;s Kitchen recipe corpus and a small supplemental list of union-territory dishes compiled for this
+              project.
+            </p>
+          </section>
+          <section>
+            <h3>Interpreting the charts</h3>
+            <p>
+              The comparisons highlight correlations, not causation. Use them as a starting point for questions alongside local
+              expertise and epidemiological context rather than definitive evidence.
+            </p>
+          </section>
+        </div>
+      </div>
+    </footer>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -24,6 +24,58 @@ body {
   color: var(--color-text-primary);
 }
 
+.about-panel {
+  margin: 0;
+  padding: 2.5rem 1.5rem 3rem;
+  background: linear-gradient(180deg, rgba(6, 19, 31, 0.95), rgba(3, 10, 19, 0.95));
+  border-top: 1px solid rgba(245, 247, 250, 0.08);
+}
+
+.about-panel__content {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.about-panel__content h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-cream);
+}
+
+.about-panel__grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.about-panel__grid section {
+  background: rgba(11, 33, 53, 0.75);
+  border-radius: 0.85rem;
+  border: 1px solid rgba(245, 247, 250, 0.08);
+  padding: 1.25rem;
+  box-shadow: 0 16px 32px rgba(4, 16, 28, 0.35);
+}
+
+.about-panel__grid h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1.02rem;
+  color: var(--color-saffron-soft);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.about-panel__grid p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  line-height: 1.55;
+  font-size: 0.95rem;
+}
+
 nav {
   display: flex;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary
- add a footer about panel that explains navigation, data provenance, and interpretation guidance
- style the panel to match the rest of the dashboard and keep content readable across breakpoints

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5eb3ece2883279091a240b26a048b